### PR TITLE
LIBITD-2131. Added "URL decoding" of "os" workstation status param

### DIFF
--- a/server/.rubocop.yml
+++ b/server/.rubocop.yml
@@ -36,6 +36,7 @@ Style/Documentation:
     - "test/test_helper.rb"
     - "test/controllers/*_controller_test.rb"
     - "test/helpers/*_helper_test.rb"
+    - "test/models/*_test.rb"
     - "test/system/*_test.rb"
 
 Style/ClassAndModuleChildren:

--- a/server/app/models/workstation_status.rb
+++ b/server/app/models/workstation_status.rb
@@ -17,6 +17,7 @@ class WorkstationStatus < ApplicationRecord
   before_save { status.downcase! }
   before_save { set_location_id }
   before_save { set_workstation_type }
+  before_save { url_decode_os }
 
   default_scope -> { order(updated_at: :desc) }
 
@@ -68,5 +69,11 @@ class WorkstationStatus < ApplicationRecord
       self.location_id = Location.find_matching_location(workstation_name)
       self.validation_messages ||= []
       self.validation_messages.push('The workstation name did not match any location!') unless location_id
+    end
+
+    def url_decode_os
+      # Reverse URL encoding of the "os" parameter, where spaces are replaced
+      # with "+" signs
+      self.os = CGI.unescape(os)
     end
 end

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -8,7 +8,8 @@ Rails.application.routes.draw do
   # Adding a constraint that allows dot will overcome this issue.
   # Here we have added a constraint that allows anything except forward-slash '/'
   get 'track/:workstation_name/:status/:os/:guest_flag/:user_hash' => 'workstation_statuses#update_status',
-      :constraints => { os: %r{[^\/]+} }
+      :constraints => { os: %r{[^\/]+} },
+      as: 'wstrack_client'
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root 'home#index'

--- a/server/test/controllers/workstation_statuses_controller_test.rb
+++ b/server/test/controllers/workstation_statuses_controller_test.rb
@@ -57,4 +57,23 @@ class WorkstationStatusesControllerTest < ActionDispatch::IntegrationTest
     assert_equal flash[:notice], 'Workstation status was successfully destroyed.'
     assert_redirected_to workstation_statuses_url
   end
+
+  test 'wstrack client endpoint should decode URL encoded "os" param' do
+    # The "os" value from the wstrack-client will be URL encoded (i.e.,
+    # spaces replaced with "+"). This test verifies that the unencoded
+    # version (with spaces) is stored.
+    os = 'Mac OS X 10.15.3'
+    encoded_os = CGI.escape(os)
+
+    get wstrack_client_url(
+      guest_flag: @workstation_status.guest_flag,
+      os: encoded_os,
+      status: @workstation_status.status,
+      user_hash: @workstation_status.user_hash,
+      workstation_name: @workstation_status.workstation_name
+    )
+
+    status = WorkstationStatus.find_by(workstation_name: @workstation_status.workstation_name)
+    assert_equal(os, status.os)
+  end
 end

--- a/server/test/models/workstation_status_test.rb
+++ b/server/test/models/workstation_status_test.rb
@@ -3,7 +3,24 @@
 require 'test_helper'
 
 class WorkstationStatusTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test '"os" param is URL-decoded on save' do
+    os = 'Mac OS X 10.15.3'
+    encoded_os = CGI.escape(os)
+
+    workstation_status = WorkstationStatus.new(
+      workstation_name: 'LIBRWKSTEMM3F383',
+      os: encoded_os,
+      user_hash: 'y3Fu6SqTdoGUdaERmrF4SA==',
+      status: 'login',
+      guest_flag: 'true'
+    )
+
+    workstation_status.save!
+    assert_equal(os, workstation_status.os)
+
+    # If an "os" is provided with spaces, it is unchanged
+    workstation_status.os = 'Test OS with Spaces'
+    workstation_status.save!
+    assert_equal('Test OS with Spaces', workstation_status.os)
+  end
 end


### PR DESCRIPTION
Added a "before_save" hook to the "WorkstationStatus" model to call the
"url_decode_os" method, which decodes the URL-encoded "os" parameter
before saving the model.

Also, in routes.rb, named the route that is called by the wstrack client
as "wstrack_client".

Added tests.

https://issues.umd.edu/browse/LIBITD-2131