### PR TITLE
LIBITD-2136. Updated "config.hosts" regex for IP addresses

### DIFF
--- a/server/config/application.rb
+++ b/server/config/application.rb
@@ -21,20 +21,26 @@ module Wstrack
 
     # Configure the hostname, when HOST is provided.
     #
-    # The HOST environment variable (typically provided by a ".env" file)
-    # is REQUIRED when running the application on a server. It is needed
-    # because this application uses SAML and Grouper, and therefore, needs
-    # a hostname in order to authenticate (this include during development).
+    # In Rails 6, middleware was added to prevent "DNS rebinding" attacks,
+    # see https://guides.rubyonrails.org/v6.1/configuring.html#configuring-middleware
+    # and https://github.com/rails/rails/pull/33145
     #
-    # Without setting the HOST, Rails will reject form submissions as not
-    # being from an allowed hosts.
+    # In the development environment, the middleware allows "localhost",
+    # and the IPv4/IPv6 loopback addresses, and so does not normally need to
+    # set. This application, however, uses SAML and Grouper, and therefore uses
+    # a hostname other than "localhost", in order to identify itself to the
+    # SAML IdP. The following sets the "config.hosts" if a "HOST" environment
+    # variable is present, which is typically provided by the ".env" file.
     #
     # It is not strictly required, because other processes (such as running
     # the tests, or performing database migrations) do not require a HOST.
-    #
     # HOST should be ignored (and config.hosts not set) when running the tests.
+    #
+    # Note: As of Rails v6.1.4.4, regular expressions should not be wrapped in
+    # '/A.../z', as it interferes with some regex manipulation Rails does
+    # internally.
     if ENV['HOST'].present? && !Rails.env.test?
-      config.hosts << /\A10\.\d+\.\d+\.\d+\z/
+      config.hosts << /10\.\d+\.\d+\.\d+/
       config.hosts << ENV['HOST']
       config.action_mailer.default_url_options = { host: ENV['HOST'] }
     end


### PR DESCRIPTION
Fixed an issue where the readiness/liveness probes in the "wstrack"
Kubernetes stack received an HTTP 403 (Forbidden) error when attempting
to access the "/ping" endpoint.

The initial "config.hosts" configuration was taken from the "umd-handle"
application, which is on Rails v6.1.3.1. In Rails v6.1.4.4, Rails
does additional processing of the regex to enable a port number of be
included. Having the "\A...\z" directives on the IP address regex
was interfering with the processing, and so was removed in this change.

Note: Rails itself wraps the regex in "\A...\z" directives, so they
are redundant, in any case.

https://issues.umd.edu/browse/LIBITD-2136