### PR TITLE
LIBITD-2117. Write historical data to CSV file

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,31 @@ project root directory.
     $ cp env_example .env
     ```
 
-    Edit the '.env" file:
+   Determine the values for the "SAML_SP_PRIVATE_KEY" and "SAML_SP_CERTIFICATE"
+   variables:
 
-    ```bash
-    $ vi .env
-    ```
+   ```bash
+   > kubectl -n test get secret wstrack-common-env-secret -o jsonpath='{.data.SAML_SP_PRIVATE_KEY}' | base64 --decode
+   > kubectl -n test get secret wstrack-common-env-secret -o jsonpath='{.data.SAML_SP_CERTIFICATE}' | base64 --decode
+   ```
 
-    No change to the ".env" file is needed for development.
+   **Note:** These values are also available from the "test/sp.crt" and
+   "test/sp.key" files in the "wstrack-saml.zip" file in the
+   "SSDR/Developer Resources/DIT SAML Configurations/" directory on Box.
+
+   Edit the '.env" file:
+
+   ```bash
+   > vi .env
+   ```
+
+   and set the parameters:
+
+   | Parameter              | Value                                |
+   | ---------------------- | ------------------------------------ |
+   | HOST                   | wstrack-local                        |
+   | SAML_SP_PRIVATE_KEY    | (Output from first kubectl command)  |
+   | SAML_SP_CERTIFICATE    | (Output from second kubectl command) |
 
 4) Run the following commands to set up the Rails application
 (with sample data):

--- a/server/README.md
+++ b/server/README.md
@@ -96,6 +96,28 @@ To run the tests:
 $ rails test:system test
 ```
 
+## CSV History File Configuration
+
+The application records workstation login/logout activity to a CSV file.
+Activity is only recorded for new records (either generated through the
+GUI, or from the API endpoint). Edits to existing records and deletions
+are *not* recorded.
+
+Activity for each day is recorded in files named for that day (the filename
+format is "YYYY-MM-DD.csv").
+
+The directory that the CSV files are written to is configured via the
+"config.x.history.storage_dir" parameter in "config/application.rb". The
+value for this parameter can be set via a "HISTORY_STORAGE_DIR" environment
+variable, otherwise it defaults to the "tmp" subdirectory in the project root.
+
+The application has been configured (via the
+"config.time_zone" parameter in "config/application.rb") to use the
+"Eastern Time (US & Canada)" timezone, to ensure that files are rolled over
+at EST/EDT midnight.
+
+The CSV file contains a "timestamp" field that reflects the "EST/EDT" timezone.
+
 ### Code Style
 
 The application uses [Rubocop](https://docs.rubocop.org/rubocop/1.25/index.html)

--- a/server/README.md
+++ b/server/README.md
@@ -110,6 +110,7 @@ The directory that the CSV files are written to is configured via the
 "config.x.history.storage_dir" parameter in "config/application.rb". The
 value for this parameter can be set via a "HISTORY_STORAGE_DIR" environment
 variable, otherwise it defaults to the "tmp" subdirectory in the project root.
+The directory will be created, if it does not exist.
 
 The application has been configured (via the
 "config.time_zone" parameter in "config/application.rb") to use the

--- a/server/app/controllers/workstation_availability_controller.rb
+++ b/server/app/controllers/workstation_availability_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class WorkstationAvailabilityController < ApplicationController
+  skip_before_action :authenticate, only: %i[index]
+
   def index
     @availability_list = WorkstationStatus.workstation_availability_list
   end

--- a/server/app/controllers/workstation_statuses_controller.rb
+++ b/server/app/controllers/workstation_statuses_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class WorkstationStatusesController < ApplicationController
+  skip_before_action :authenticate, only: %i[update_status]
+
   before_action :set_workstation_status, only: %i[show edit update destroy]
 
   # GET /workstation_statuses or /workstation_statuses.json

--- a/server/app/models/workstation_status.rb
+++ b/server/app/models/workstation_status.rb
@@ -4,6 +4,8 @@
 class WorkstationStatus < ApplicationRecord
   include WorkstationAvailability
 
+  after_commit { |status| RecordHistory.perform(status) }
+
   MAC = 'MAC'
   PC = 'PC'
   LOGIN = 'login'

--- a/server/app/services/application_service.rb
+++ b/server/app/services/application_service.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Helper base class for calling "service" objects.
+# See https://www.toptal.com/ruby-on-rails/rails-service-objects-tutorial
+class ApplicationService
+  def self.perform(*args)
+    new.perform(*args)
+  end
+end

--- a/server/app/services/record_history.rb
+++ b/server/app/services/record_history.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+# Records workstation status records in a CSV-formatted history file.
+class RecordHistory < ApplicationService
+  # Mutex to prevent multiple threads from writing to the file simultaneously
+  @semaphore = Mutex.new
+
+  class << self
+    attr_reader :semaphore
+  end
+
+  def perform(workstation_status)
+    return unless new_record?(workstation_status)
+
+    self.class.semaphore.synchronize do
+      timestamp = workstation_status.updated_at
+      csv_record = as_csv(workstation_status, timestamp)
+      write_to_file(timestamp, csv_record)
+    end
+  end
+
+  # Returns true if the given WorkstationStatus is a newly-created record,
+  # false otherwise.
+  def new_record?(workstation_status)
+    workstation_status.saved_change_to_id?
+  end
+
+  def write_to_file(timestamp, csv_record)
+    return if storage_dir == File::NULL
+
+    filename = filename(timestamp)
+    storage_path = Pathname.new(storage_dir).join(filename)
+
+    create_file(storage_path, csv_record) unless storage_path.exist?
+    write_row(storage_path, csv_record)
+  end
+
+  def create_file(storage_path, csv_record)
+    CSV.open(storage_path, 'ab') do |csv|
+      csv << csv_record.keys
+    end
+  end
+
+  def write_row(storage_path, csv_record)
+    CSV.open(storage_path, 'ab') do |csv|
+      csv << csv_record.values
+    end
+  end
+
+  def as_csv(workstation_status, timestamp) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    csv_record = {}
+    csv_record[:id] = workstation_status.id
+    csv_record[:workstation_name] = workstation_status.workstation_name
+    csv_record[:guest_flag] = workstation_status.guest_flag ? 't' : 'f'
+    csv_record[:os] = workstation_status.os
+    csv_record[:status] = workstation_status.status
+    csv_record[:timestamp] = timestamp.strftime('%Y-%m-%d %H:%M:%S.%L')
+    csv_record[:user_hash] = workstation_status.user_hash
+    csv_record[:type] = workstation_status.workstation_type
+    csv_record[:location] = workstation_status.location ? workstation_status.location.name : nil
+    csv_record
+  end
+
+  def storage_dir
+    Rails.configuration.x.history.storage_dir
+  end
+
+  def filename(timestamp)
+    base_filename = timestamp.in_time_zone.strftime('%Y-%m-%d')
+    extension = 'csv'
+    "#{base_filename}.#{extension}"
+  end
+end

--- a/server/app/views/workstation_statuses/index.html.erb
+++ b/server/app/views/workstation_statuses/index.html.erb
@@ -37,7 +37,7 @@
         <td><%= workstation_status.user_hash %></td>
         <td><%= workstation_status.status %></td>
         <td><%= workstation_status.guest_flag %></td>
-        <td><%= workstation_status.updated_at %></td>
+        <td><%= workstation_status.updated_at.strftime('%Y-%m-%d %H:%M:%S %Z') %></td>
       </tr>
     <% end %>
   </tbody>

--- a/server/config/application.rb
+++ b/server/config/application.rb
@@ -16,7 +16,7 @@ module Wstrack
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Eastern Time (US & Canada)'
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Configure the hostname, when HOST is provided.
@@ -44,5 +44,7 @@ module Wstrack
       config.hosts << ENV['HOST']
       config.action_mailer.default_url_options = { host: ENV['HOST'] }
     end
+
+    config.x.history.storage_dir = ENV['HISTORY_STORAGE_DIR'] || Rails.root.join('tmp')
   end
 end

--- a/server/config/environments/test.rb
+++ b/server/config/environments/test.rb
@@ -57,4 +57,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Send history records to /dev/null
+  config.x.history.storage_dir = File::NULL
 end

--- a/server/lib/tasks/sample_data.rake
+++ b/server/lib/tasks/sample_data.rake
@@ -7,7 +7,10 @@ namespace :db do
   desc 'Populates the database with sample data'
   task populate_sample_data: :environment do
     require 'faker'
-        
+
+    # Suppress history CSV file output
+    Rails.configuration.x.history.storage_dir = File::NULL
+
     Location.find_or_create_by(code: 'MCK1F', name: 'McKeldin Library 1st floor', regex: '(?i)^LIBRWKMCK[PM]1F.*$')
     Location.find_or_create_by(code: 'MCK2F', name: 'McKeldin Library 2nd floor', regex: '(?i)^LIBRWKMCK[PM]2F.*$')
     Location.find_or_create_by(code: 'MCK3F', name: 'McKeldin Library 3rd floor', regex: '(?i)^LIBRWKMCK[PM]3F.*$')
@@ -57,7 +60,7 @@ namespace :db do
             num_tries -= 1
           end
           status.os = status.workstation_name[10] == "P" ? "WINDOWS_NT" : MAC_OS_LIST.sample
-          status.user_hash = Base64.encode64(Digest::MD5.digest(Faker::Internet.user_name(specifier: 8)))
+          status.user_hash = Base64.encode64(Digest::MD5.digest(Faker::Internet.user_name(specifier: 8))).chomp
           status.status = STATUS_LIST.sample
           status.guest_flag = Faker::Boolean.boolean
           created_at = generate_created_at(num, num_status_per_location, last_created_at)

--- a/server/test/integration/workstation_availability_controller_test.rb
+++ b/server/test/integration/workstation_availability_controller_test.rb
@@ -41,4 +41,12 @@ class WorkstationAvailabilityControllerTest < ActionDispatch::IntegrationTest
     assert_match Mime[:xml].to_str, response.content_type
     assert_equal file_fixture('avalability_list.xml').read, response.body
   end
+
+  test 'index is accessible without login' do
+    reset_login
+
+    get availability_url
+    assert_response :success
+    assert_select 'h1', 'Workstation Availability By Location'
+  end
 end

--- a/server/test/integration/workstation_statuses_controller_test.rb
+++ b/server/test/integration/workstation_statuses_controller_test.rb
@@ -68,18 +68,21 @@ class WorkstationStatusesControllerTest < ActionDispatch::IntegrationTest
     # The "os" value from the wstrack-client will be URL encoded (i.e.,
     # spaces replaced with "+"). This test verifies that the unencoded
     # version (with spaces) is stored.
-    os = 'Mac OS X 10.15.3'
+    os = 'Test OS with spaces'
     encoded_os = CGI.escape(os)
 
-    get wstrack_client_url(
-      guest_flag: @workstation_status.guest_flag,
-      os: encoded_os,
-      status: @workstation_status.status,
-      user_hash: @workstation_status.user_hash,
-      workstation_name: @workstation_status.workstation_name
-    )
+    reset_login # endpoint is available without login
 
-    status = WorkstationStatus.find_by(workstation_name: @workstation_status.workstation_name)
+    get wstrack_client_url(
+      guest_flag: 'f',
+      os: encoded_os,
+      status: 'login',
+      user_hash: 'test_hash',
+      workstation_name: 'TEST_WORKSTATION'
+    )
+    assert_response :success
+
+    status = WorkstationStatus.find_by(workstation_name: 'TEST_WORKSTATION')
     assert_equal(os, status.os)
   end
 end

--- a/server/test/models/workstation_status_test.rb
+++ b/server/test/models/workstation_status_test.rb
@@ -3,6 +3,14 @@
 require 'test_helper'
 
 class WorkstationStatusTest < ActiveSupport::TestCase
+  def setup
+    @current_storage_dir = Rails.configuration.x.history.storage_dir
+  end
+
+  def teardown
+    Rails.configuration.x.history.storage_dir = @current_storage_dir
+  end
+
   test '"os" param is URL-decoded on save' do
     os = 'Mac OS X 10.15.3'
     encoded_os = CGI.escape(os)
@@ -22,5 +30,61 @@ class WorkstationStatusTest < ActiveSupport::TestCase
     workstation_status.os = 'Test OS with Spaces'
     workstation_status.save!
     assert_equal('Test OS with Spaces', workstation_status.os)
+  end
+
+  test 'new entry is recorded to history after commit' do
+    Dir.mktmpdir do |temp_dir|
+      Rails.configuration.x.history.storage_dir = temp_dir
+
+      os = 'Mac OS X 10.15.3'
+      encoded_os = CGI.escape(os)
+
+      travel_to Time.parse('April 22, 2022 13:00:00 EDT') do
+        workstation_status = WorkstationStatus.new(
+          workstation_name: 'LIBRWKSTEMM3F383',
+          os: encoded_os,
+          user_hash: 'y3Fu6SqTdoGUdaERmrF4SA==',
+          status: 'login',
+          guest_flag: 'true'
+        )
+
+        workstation_status.save!
+      end
+
+      expected_storage_path = Pathname.new(temp_dir).join('2022-04-22.csv')
+      assert expected_storage_path.size? # File exists and has non-zero size
+    end
+  end
+
+  test 'new entry with error is not recorded to history' do
+    Dir.mktmpdir do |temp_dir|
+      Rails.configuration.x.history.storage_dir = temp_dir
+
+      travel_to Time.parse('April 22, 2022 13:00:00 EDT') do
+        workstation_status = WorkstationStatus.new(
+          user_hash: 'y3Fu6SqTdoGUdaERmrF4SA==',
+          status: 'login',
+          guest_flag: 'true'
+        )
+
+        workstation_status.save
+        assert workstation_status.errors.any?
+      end
+
+      expected_storage_path = Pathname.new(temp_dir).join('2022-04-22.csv')
+      assert_not expected_storage_path.exist?
+    end
+  end
+
+  test 'edited entry is not recorded to history' do
+    Dir.mktmpdir do |temp_dir|
+      Rails.configuration.x.history.storage_dir = temp_dir
+
+      workstation_status = workstation_statuses(:epl_mac_ws)
+      workstation_status.os = 'PC'
+      workstation_status.save!
+
+      assert Dir.empty?(temp_dir), 'Entry should not have been written to history file.'
+    end
   end
 end

--- a/server/test/services/record_history_test.rb
+++ b/server/test/services/record_history_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RecordHistoryTest < ActiveSupport::TestCase
+  test 'filename uses local timezone for generating filenames' do
+    record_history = RecordHistory.new
+
+    # Following assumes local timezone is 'Eastern Time (US & Canada)'
+    test_cases = [
+      { timestamp: Time.parse('April 22, 2022 00:00:00 UTC'), expected: '2022-04-21.csv' },
+      { timestamp: Time.parse('April 22, 2022 03:59:59 UTC'), expected: '2022-04-21.csv' },
+      { timestamp: Time.parse('April 22, 2022 04:00:00 UTC'), expected: '2022-04-22.csv' },
+      { timestamp: Time.parse('January 1, 2023 00:00:00 UTC'), expected: '2022-12-31.csv' },
+      { timestamp: Time.parse('January 1, 2023 04:59:59 UTC'), expected: '2022-12-31.csv' },
+      { timestamp: Time.parse('January 1, 2023 05:00:00 UTC'), expected: '2023-01-01.csv' },
+
+      { timestamp: Time.parse('April 22, 2022 00:00:00 EDT'), expected: '2022-04-22.csv' },
+      { timestamp: Time.parse('April 22, 2022 23:59:59 EDT'), expected: '2022-04-22.csv' },
+      { timestamp: Time.parse('January 1, 2023 00:00:00 EST'), expected: '2023-01-01.csv' }
+    ]
+
+    test_cases.each do |test|
+      expected_filename = test[:expected]
+      actual_filename = record_history.filename(test[:timestamp])
+      assert_equal expected_filename, actual_filename, "timestamp: #{test[:timestamp]}"
+    end
+  end
+
+  test 'as_csv returns a Hash of WorkstationStatus info record' do
+    workstation_status = WorkstationStatus.new(
+      {
+        workstation_name: 'LIBRWKARTM1F123', os: 'Mac OS X 10.15.3',
+        user_hash: 'y3Fu6SqTdoGUdaERmrF4SA==', status: 'login',
+        guest_flag: true
+      }
+    )
+    workstation_status.save!
+
+    timestamp = Time.zone.now
+    csv_hash = RecordHistory.new.as_csv(workstation_status, timestamp)
+
+    expected_hash = {
+      id: workstation_status.id, workstation_name: 'LIBRWKARTM1F123',
+      os: 'Mac OS X 10.15.3', user_hash: 'y3Fu6SqTdoGUdaERmrF4SA==',
+      status: 'login', guest_flag: 't', location: 'Art Library 1st floor',
+      type: 'MAC', timestamp: timestamp.strftime('%Y-%m-%d %H:%M:%S.%L')
+    }
+
+    assert_equal expected_hash, csv_hash
+  end
+
+  test 'as_csv returns empty location and type when not populated in WorkstationStatus' do
+    workstation_status = WorkstationStatus.new(
+      {
+        workstation_name: 'TEST', os: 'Mac OS X 10.15.3',
+        user_hash: 'y3Fu6SqTdoGUdaERmrF4SA==', status: 'login',
+        guest_flag: true
+      }
+    )
+
+    workstation_status.save!
+
+    timestamp = Time.zone.now
+    csv_hash = RecordHistory.new.as_csv(workstation_status, timestamp)
+
+    expected_hash = {
+      id: workstation_status.id, workstation_name: 'TEST',
+      os: 'Mac OS X 10.15.3', user_hash: 'y3Fu6SqTdoGUdaERmrF4SA==',
+      status: 'login', guest_flag: 't', location: nil,
+      type: nil, timestamp: timestamp.strftime('%Y-%m-%d %H:%M:%S.%L')
+    }
+
+    assert_equal expected_hash, csv_hash
+  end
+end

--- a/server/test/test_helper.rb
+++ b/server/test/test_helper.rb
@@ -79,6 +79,8 @@ class ActiveSupport::TestCase
 
   # Clear any login credentials
   def reset_login
+    reset! # Reset the existing session instance
+    OmniAuth.config.test_mode = false
     OmniAuth.config.mock_auth[:saml] = nil
     Rails.application.env_config['omniauth.auth'] = nil
   end


### PR DESCRIPTION
Added "RecordHistory" service object to write new login/logout
activity to a CSV file that is rolled-over every day (filenames have
the form "YYYY-MM-DD.csv"). RecordHistory uses a Ruby Mutex object
to synchronize the file writes, to prevent multiple threads from
interfering with each other.

The directory where the CSV are written can be modified using a
"HISTORY_STORAGE_DIR" environment variable, otherwise the "tmp"
subdirectory in the project root is used. For the "test" environment,
the storage directory is set to "File::NULL" (equivalent to Unix
"/dev/null").

Modified the "WorkstationStatus" model to call "RecordHistory" using
an "after_commit" hooks. This prevents invalid WorkstationStatuses from
being recorded. The "RecordHistory" object only writes entries for
"new" WorkstationStatus models -- edits to existing models are not
recorded.

Configured the application to default to using the
'Eastern Time (US & Canada)' timezone, and modified the GUI to display
the timezone using the timezone abbreviation (i.e. "EDT" instead of
"-0400").

https://issues.umd.edu/browse/LIBITD-2117