### PR TITLE
LIBITD-2119. Add pagination and sort to workstation status

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -40,6 +40,9 @@ gem 'omniauth-rails_csrf_protection', '~> 1.0.1'
 # Sorting
 gem 'ransack', '~> 3.1.0'
 
+# Pagination
+gem 'kaminari', '~> 1.2.2'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/server/Gemfile
+++ b/server/Gemfile
@@ -37,6 +37,9 @@ gem 'dotenv-rails', '>= 2.7.6'
 gem 'omniauth-saml', '~> 2.1.0'
 gem 'omniauth-rails_csrf_protection', '~> 1.0.1'
 
+# Sorting
+gem 'ransack', '~> 3.1.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -188,6 +188,10 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
+    ransack (3.1.0)
+      activerecord (>= 6.0.4)
+      activesupport (>= 6.0.4)
+      i18n
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -294,6 +298,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4, >= 6.1.4.6)
   rails-controller-testing
+  ransack (~> 3.1.0)
   rubocop (= 1.25.1)
   rubocop-checkstyle_formatter (= 0.5.0)
   rubocop-rails (= 2.13.2)

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -106,6 +106,18 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -290,6 +302,7 @@ DEPENDENCIES
   dotenv-rails (>= 2.7.6)
   faker (>= 2.17.0)
   jbuilder (~> 2.7)
+  kaminari (~> 1.2.2)
   listen (~> 3.3)
   minitest-reporters
   omniauth-rails_csrf_protection (~> 1.0.1)

--- a/server/app/assets/stylesheets/application.scss
+++ b/server/app/assets/stylesheets/application.scss
@@ -18,3 +18,15 @@
 .field_with_errors {
   display: inline;
 }
+
+// Set style of disabled pagination buttons
+.pagination .disabled {
+  color: #777777;
+  cursor: not-allowed;
+}
+
+.pagination > li > span:hover,  .pagination > li > span:focus {
+  color: #777777;
+  cursor: not-allowed;
+  background-color: #fff;
+}

--- a/server/app/controllers/workstation_statuses_controller.rb
+++ b/server/app/controllers/workstation_statuses_controller.rb
@@ -9,7 +9,7 @@ class WorkstationStatusesController < ApplicationController
   def index
     @q = WorkstationStatus.ransack(params[:q])
     @q.sorts = 'updated_at desc' if @q.sorts.empty?
-    @workstation_statuses = @q.result
+    @workstation_statuses = @q.result.page params[:page]
   end
 
   # GET /workstation_statuses/1 or /workstation_statuses/1.json

--- a/server/app/controllers/workstation_statuses_controller.rb
+++ b/server/app/controllers/workstation_statuses_controller.rb
@@ -7,7 +7,9 @@ class WorkstationStatusesController < ApplicationController
 
   # GET /workstation_statuses or /workstation_statuses.json
   def index
-    @workstation_statuses = WorkstationStatus.all
+    @q = WorkstationStatus.ransack(params[:q])
+    @q.sorts = 'updated_at desc' if @q.sorts.empty?
+    @workstation_statuses = @q.result
   end
 
   # GET /workstation_statuses/1 or /workstation_statuses/1.json

--- a/server/app/views/kaminari/_first_page.html.erb
+++ b/server/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote %>
+</li>

--- a/server/app/views/kaminari/_gap.html.erb
+++ b/server/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='disabled'>
+  <%= content_tag :a, raw(t 'views.pagination.truncate') %>
+</li>

--- a/server/app/views/kaminari/_last_page.html.erb
+++ b/server/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, { remote: remote } %>
+</li>

--- a/server/app/views/kaminari/_next_page.html.erb
+++ b/server/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote %>
+</li>

--- a/server/app/views/kaminari/_next_page.html.erb
+++ b/server/app/views/kaminari/_next_page.html.erb
@@ -1,3 +1,7 @@
 <li>
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote %>
+  <% if current_page.last? %>
+    <span class="next disabled"><%= raw(t 'views.pagination.next') %></span>
+  <% else %>
+    <%= link_to raw(t 'views.pagination.next'), url, rel: 'next', remote: remote %>
+  <% end %>
 </li>

--- a/server/app/views/kaminari/_page.html.erb
+++ b/server/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class='active'>
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel %>
+  </li>
+<% else %>
+  <li>
+    <%= link_to page, url, remote: remote, rel: page.rel %>
+  </li>
+<% end %>

--- a/server/app/views/kaminari/_paginator.html.erb
+++ b/server/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,15 @@
+<%= paginator.render do -%>
+  <ul class="pagination">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <%= next_page_tag unless current_page.last? %>
+    <%= last_page_tag unless current_page.last? %>
+  </ul>
+<% end -%>

--- a/server/app/views/kaminari/_paginator.html.erb
+++ b/server/app/views/kaminari/_paginator.html.erb
@@ -1,7 +1,6 @@
 <%= paginator.render do -%>
   <ul class="pagination">
-    <%= first_page_tag unless current_page.first? %>
-    <%= prev_page_tag unless current_page.first? %>
+    <%= prev_page_tag %>
     <% each_page do |page| -%>
       <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
         <%= page_tag page %>
@@ -9,7 +8,6 @@
         <%= gap_tag %>
       <% end -%>
     <% end -%>
-    <%= next_page_tag unless current_page.last? %>
-    <%= last_page_tag unless current_page.last? %>
+    <%= next_page_tag %>
   </ul>
 <% end -%>

--- a/server/app/views/kaminari/_prev_page.html.erb
+++ b/server/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote %>
+</li>

--- a/server/app/views/kaminari/_prev_page.html.erb
+++ b/server/app/views/kaminari/_prev_page.html.erb
@@ -1,3 +1,7 @@
 <li>
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote %>
+  <% if current_page.first? %>
+    <span class="prev disabled"><%= raw(t 'views.pagination.previous') %></span>
+  <% else %>
+    <%= link_to raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote %>
+  <% end %>
 </li>

--- a/server/app/views/workstation_statuses/index.html.erb
+++ b/server/app/views/workstation_statuses/index.html.erb
@@ -9,6 +9,8 @@
   </div>
 </div>
 
+<%= paginate @workstation_statuses %>
+
 <table class="table table-striped statuses">
   <thead>
     <tr>

--- a/server/app/views/workstation_statuses/index.html.erb
+++ b/server/app/views/workstation_statuses/index.html.erb
@@ -12,14 +12,14 @@
 <table class="table table-striped statuses">
   <thead>
     <tr>
-      <th>Name</th>
+      <th><%= sort_link(@q, :workstation_name, 'Name') %></th>
       <th>Location</th>
       <th>Type</th>
-      <th>Os</th>
-      <th>User hash</th>
-      <th>Status</th>
-      <th>Guest flag</th>
-      <th>Timestamp</th>
+      <th><%= sort_link(@q, :os, 'Os') %></th>
+      <th><%= sort_link(@q, :user_hash, 'User hash') %></th>
+      <th><%= sort_link(@q, :status, 'Status') %></th>
+      <th><%= sort_link(@q, :guest_flag, 'Guest flag') %></th>
+      <th><%= sort_link(@q, :updated_at, 'Timestamp') %></th>
     </tr>
   </thead>
 

--- a/server/config/initializers/kaminari_config.rb
+++ b/server/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/server/config/locales/en.yml
+++ b/server/config/locales/en.yml
@@ -31,3 +31,8 @@
 
 en:
   hello: "Hello world"
+
+  views:
+    pagination:
+      previous: ← Previous
+      next: Next →


### PR DESCRIPTION
Used the "ransack" (for sorting) and "kaminari" gem (for pagination). Some other UMD Rails applications use the "will_paginate" gem, but according to the website, this gem is now is "maintenance mode".  Ruby toolbox also indicates that the "kaminari" gem is in much wider use - https://www.ruby-toolbox.com/categories/pagination

* Added "ransack" gem to support sorting the "Workstation Statuses" table. The "Location" and "Type" fields are not sortable, because they are "derived" fields, and so are not present in the database.

* Added "kaminari" gem, and ran the following command to theme the pagination bar using the Bootstrap 3 styling:

    ```bash
    $rails g kaminari:views bootstrap3
    ```

* Adjusted the Kaminari pagination bar styling to match the "umd-handle" application, which also uses the "kaminari" gem. Added the "server/config/initializers/kaminari_config.rb" file by running the following command:

    ```bash
    $ rails g kaminari:config
    ```
https://issues.umd.edu/browse/LIBITD-2119