### PR TITLE
LIBITD-2142. Removed "id" field from CSV history file

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -137,9 +137,8 @@ where:
 ## CSV History File Configuration
 
 The application records workstation login/logout activity to a CSV file.
-Activity is only recorded for new records (either generated through the
-GUI, or from the API endpoint). Edits to existing records and deletions
-are *not* recorded.
+Only activity on the "wstrack_client" endpoint ("/track") is recorded.
+New records, edits, or deletions through the GUI are *not* recorded.
 
 Activity for each day is recorded in files named for that day (the filename
 format is "YYYY-MM-DD.csv").

--- a/server/app/services/record_history.rb
+++ b/server/app/services/record_history.rb
@@ -26,9 +26,8 @@ class RecordHistory < ApplicationService
   end
 
   # Returns a Hash representing the CSV row to record
-  def as_csv(workstation_status, timestamp) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+  def as_csv(workstation_status, timestamp) # rubocop:disable Metrics/AbcSize
     csv_record = {}
-    csv_record[:id] = workstation_status.id
     csv_record[:workstation_name] = workstation_status.workstation_name
     csv_record[:guest_flag] = workstation_status.guest_flag ? 't' : 'f'
     csv_record[:os] = workstation_status.os

--- a/server/test/services/record_history_test.rb
+++ b/server/test/services/record_history_test.rb
@@ -41,7 +41,7 @@ class RecordHistoryTest < ActiveSupport::TestCase
     csv_hash = RecordHistory.new.as_csv(workstation_status, timestamp)
 
     expected_hash = {
-      id: workstation_status.id, workstation_name: 'LIBRWKARTM1F123',
+      workstation_name: 'LIBRWKARTM1F123',
       os: 'Mac OS X 10.15.3', user_hash: 'y3Fu6SqTdoGUdaERmrF4SA==',
       status: 'login', guest_flag: 't', location: 'Art Library 1st floor',
       type: 'MAC', timestamp: timestamp.strftime('%Y-%m-%d %H:%M:%S.%L')
@@ -65,7 +65,7 @@ class RecordHistoryTest < ActiveSupport::TestCase
     csv_hash = RecordHistory.new.as_csv(workstation_status, timestamp)
 
     expected_hash = {
-      id: workstation_status.id, workstation_name: 'TEST',
+      workstation_name: 'TEST',
       os: 'Mac OS X 10.15.3', user_hash: 'y3Fu6SqTdoGUdaERmrF4SA==',
       status: 'login', guest_flag: 't', location: nil,
       type: nil, timestamp: timestamp.strftime('%Y-%m-%d %H:%M:%S.%L')


### PR DESCRIPTION
Removed the "id" field from the CSV history file, as it is not
particularly useful, as there will be multiple instances of the same
"id" in a CSV file, as WorkstationStatus entries that already exist are
updated, not created for each client access.
So when a particular workstation reports a login and later reports a
logout, the CSV file will contain two entries with the same "id" – the
id of the WorkstationStatus record in the database.

This seemed confusing as it was not in keeping with the usual definition
of an id field. Additionally, the id field contains no particularly
useful information.

https://issues.umd.edu/browse/LIBITD-2142