### PR TITLE
LIBITD-2487. Fix Jenkinsfile for Jenkins v2.440.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,9 @@ pipeline {
       post {
         always {
           // Collect Rubocop reports
-          recordIssues(tools: [ruboCop(reportEncoding: 'UTF-8')], unstableTotalAll: 1)
+          recordIssues(tools: [ruboCop(reportEncoding: 'UTF-8')],
+                       qualityGates: [[threshold: 1, type: 'TOTAL', criticality: 'UNSTABLE']]
+          )
 
           // Collect coverage reports
           publishHTML([


### PR DESCRIPTION
Updated the "recordIssues" directive in the "Jenkinsfile" to use the "qualityGates" parameter, instead of the obsolete "unstableTotalAll" parameter.

https://umd-dit.atlassian.net/browse/LIBITD-2487